### PR TITLE
Promote development → test (2 commits)

### DIFF
--- a/.github/instructions/project-context.instructions.md
+++ b/.github/instructions/project-context.instructions.md
@@ -20,8 +20,11 @@ only the map to them.
   claim it with `dx project claim <issue> --repo <owner/name>` (self-assigns + sets `In progress`
   atomically, one at a time; refuses if already assigned unless `--force`). Issue bodies follow the
   work-item form (`### Why` / `### Scope / contract` / `### Acceptance` / `### Links`);
-  `dx project lint` flags any that drift from it, and `dx project audit` flags any item whose
-  `Status` disagrees with the real issue/PR state (e.g. marked Done but still open).
+  `dx project lint` flags any that drift from it (or that are missing an `Initiative`/`Size`), and
+  `dx project audit` flags inconsistencies — a stale `Status` vs. the real issue/PR state (e.g.
+  marked Done but still open), an `In progress` item with no assignee or no Snapshot in 14 days, or
+  a `Ready`/`Backlog` item that's already assigned. `dx project stats 3` gives a roll-up (`Status` ×
+  `Initiative`, WIP, oldest `In progress`).
 - **🧭 Decisions** (org GitHub Discussions, Decisions category) — _why_: durable architecture
   decisions, one per post — what was chosen, why, alternatives rejected. List recent ones with
   `dx decision list`.
@@ -34,7 +37,8 @@ only the map to them.
 ## How to use it
 
 - **"What's the status / what's next?"** → the board (issue + its latest comment); for a cross-repo
-  effort, filter by its `Initiative`.
+  effort, filter by its `Initiative`. `dx project stats 3` gives the roll-up, and
+  `dx project mine 3` lists your own `In progress`/`In review` items.
 - **Before starting non-trivial work** → find or create the board issue first; don't let code get
   ahead of the plan. Check the pickup queue (`dx project items 3 --status Ready --no-assignee`, or
   `dx project board 3 --initiative <name>`) for an existing pickable issue. If none exists, open one
@@ -69,7 +73,9 @@ only the map to them.
   (each flag repeatable) — the command owns the exact format, so don't hand-write the comment.
   Omitted sections render `- none`. When a decision crystallizes, post it with
   `dx decision add --title … --body-file …` (or `--status/--context/--decision/--consequences …`) —
-  the command owns the canonical form, and `dx decision lint` flags any that drift from it.
+  the command owns the canonical form, and `dx decision lint` flags any that drift from it. For a
+  whole-initiative heartbeat (rather than a single issue), post a project-level update with
+  `dx project update 3 --state <ON_TRACK|AT_RISK|OFF_TRACK|COMPLETE> [--target <date>] [--body …]`.
 - **End each planning/discovery session (no code changed) the same way.** A conversation that only
   produces ideas is not done until every idea worth keeping has a durable home. Before closing out:
   audit each design thread discussed, including tangential or explicitly-deferred ones, and confirm

--- a/.github/instructions/project-context.instructions.md
+++ b/.github/instructions/project-context.instructions.md
@@ -25,6 +25,11 @@ only the map to them.
   marked Done but still open), an `In progress` item with no assignee or no Snapshot in 14 days, or
   a `Ready`/`Backlog` item that's already assigned. `dx project stats 3` gives a roll-up (`Status` ×
   `Initiative`, WIP, oldest `In progress`).
+- **Sizing** — the board `Size` (XS/S/M/L/XL) estimates one agent's **session effort**: `XS` a
+  one-file/one-command tweak; `S` a single file plus its tests in one focused session; `M` a few
+  files, one session end-to-end; `L` multi-file or spanning more than one session; `XL` too big to
+  pick up as-is — split it before starting. Set it when filing; `dx project lint` requires it on
+  every non-Done item, and an `XL` is a signal to split, not a valid pickable size.
 - **🧭 Decisions** (org GitHub Discussions, Decisions category) — _why_: durable architecture
   decisions, one per post — what was chosen, why, alternatives rejected. List recent ones with
   `dx decision list`.
@@ -101,7 +106,8 @@ only the map to them.
   `--wait`. Never open a PR that skips a hop (`development` straight into `main`) or runs the chain
   backwards — repos with all three branches enforce this with a required `Source Branch` status
   check, not just convention. Repos with only a `main` branch (`ui`, `dx`, the `*-example`
-  templates) push directly to `main`; there's no chain to reason about.
+  templates) have no promotion chain, but still route **issue-resolving** work through a short-lived
+  feature-branch PR into `main` (see below) rather than pushing the resolving change straight to it.
 - **Feature branches** — cut from `development` (or `main` for single-branch repos), named for the
   work in `kebab-case`. PR them back into `development` — not `test` or `main` directly — so the
   change rides the normal promotion chain instead of bypassing it. Open (or refresh) the PR with
@@ -112,6 +118,14 @@ only the map to them.
   before deleting. **Unmerged** branches have no fixed TTL while active, but treat one as stale if
   its PR has had no commits or review activity for ~2 weeks — at that point either resume the work
   or close the PR and delete the branch rather than letting it rot.
+- **Issue-resolving PRs** — any branch that resolves a board issue merges through a PR carrying a
+  `Closes #N` trailer into the repo's **default branch** (harvested automatically by
+  `dx git feature`/`dx git merge`), so the merge auto-closes the issue and populates its GitHub
+  **Development** link — the durable issue→code trail. Only a closing keyword creates that link;
+  intermediate promotion hops keep `Refs #N` (a bare reference: no premature close, no link), and
+  the `Closes #N` lands on the hop into the default branch. This is why single-branch repos open a
+  PR for issue work instead of pushing to `main`: a direct push closes nothing and leaves no linked
+  PR.
 - **Worktrees** — prefer `git worktree add ../<repo>-<branch> <branch>` over switching branches in
   the primary clone when more than one thing is in flight (e.g. a feature alongside an urgent fix).
   This keeps the primary checkout on `development` so other tooling (dev servers, background syncs)


### PR DESCRIPTION
Promotes `development` → `test` (2 commits).

- docs(project-context): note dx project mine/stats/update and tighter audit/lint
- docs(project-context): sync sizing rubric and issue-PR linkage rule