### PR TITLE
chore(deps): bump rqlite test target 9.4.5 -> 10.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,20 +59,20 @@ if (result.ok) {
 
 | rqlite version | Client version | Status |
 | -------------- | -------------- | ------ |
-| 9.x            | 0.x            | Tested |
+| 10.x           | 0.x            | Tested |
 
 The integration test suite runs against rqlite via Docker. Override the version with the
 `RQLITE_VERSION` environment variable:
 
 ```bash
-RQLITE_VERSION=9.4.5 docker compose -f docker-compose.test.yaml up -d
+RQLITE_VERSION=10.2.7 docker compose -f docker-compose.test.yaml up -d
 ```
 
 Use `serverVersion()` at runtime to check the connected server:
 
 ```ts
 const ver = await client.serverVersion()
-if (ver.ok) console.log(ver.value) // "v9.4.5"
+if (ver.ok) console.log(ver.value) // "v10.2.7"
 ```
 
 ## Usage

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,6 +1,6 @@
 services:
   rqlite:
-    image: rqlite/rqlite:${RQLITE_VERSION:-9.4.5}@sha256:cf4d7d35e0ce1532e4578ec580dda63554853c010371e3cbe2676a95f5003fb7
+    image: rqlite/rqlite:${RQLITE_VERSION:-10.2.7}@sha256:507da6e6bcf41011f784bcbe4dce5900f84aa027ad6283a50a45c4238e969d3a
     ports:
       - "4001:4001"
       - "4002:4002"


### PR DESCRIPTION
Bump the integration-test rqlite container to 10.2.7 (re-pinned to its
current registry digest, verified with docker buildx imagetools inspect)
and update the documented compatibility from 9.x to 10.x.

Verified the client against a live rqlite 10.x server: serverVersion,
status, ready, nodes, and query (SELECT 1) all succeed.
